### PR TITLE
Output the whole binary at once in pprint and allow just formatting the binary

### DIFF
--- a/src/binpp.erl
+++ b/src/binpp.erl
@@ -15,6 +15,7 @@
 -module(binpp).
 -author('Adam Rutkowski adam@mtod.org').
 -export([pprint/1, pprint/3]).
+-export([pbin/1, pbin/3]).
 -export([cmprint/2]).
 -export([from_str/1, from_str/2]).
 -export([format/1, format/2]).
@@ -61,6 +62,19 @@ pprint(Bin, Pos, Len) when Len =< size(Bin) ->
 
 pprint(Bin, Pos, _) ->
     pprint(binary:part(Bin, Pos, size(Bin)-Pos)).
+
+-spec pbin(binary()) -> iolist().
+
+pbin(Bin) ->
+    {ok, Octets} = convert(Bin, hex),
+    Buckets = buckets(16, Octets),
+    lists:map(fun print_bucket/1, Buckets).
+
+pbin(Bin, Pos, Len) when Len =< size(Bin) ->
+    pbin(binary:part(Bin, Pos, Len));
+
+pbin(Bin, Pos, _) ->
+    pbin(binary:part(Bin, Pos, size(Bin)-Pos)).
 
 -spec cmprint(binary(), binary()) -> ok.
 


### PR DESCRIPTION
When using binpp:pprint/1 from several processes at the same time, the output of pprint/1 of several binaries might be mixed because each line of the binary is printed separately.
The first commit prints the whole binary at once when using pprint/1.

It's useful to be able to use the output of pprint/1 with error_logger or something else instead of printing it to the shell so I added pbin/1 to return an iolist. You can print it with error_logger:info_msg("~p~n", [binpp:pbin(<<"mybin">>)]).

pprint/1 can use pbin/1 but I didn't change that for simplicity.
You'll might want to change the name of the pbin function.

Thanks
